### PR TITLE
Fix pagination in base table and session history

### DIFF
--- a/src/components/dashboard/performance-improvement/NewPerformanceImprovementDialog.tsx
+++ b/src/components/dashboard/performance-improvement/NewPerformanceImprovementDialog.tsx
@@ -49,7 +49,7 @@ function NewPerformanceImprovementDialog() {
   );
   const [pagination, setPagination] = useState({
     pageIndex: 0,
-    pageSize: 20,
+    pageSize: 10,
   });
 
   const { data, error, isLoading } = useSessionHistory(

--- a/src/components/tables/base-table/index.tsx
+++ b/src/components/tables/base-table/index.tsx
@@ -73,7 +73,7 @@ export function BaseTable<TData, TValue>({
     const navigate = useNavigate();
     const user = JSON.parse(localStorage.getItem("user") || "{}");
 
-    const calculatedPageCount = Math.ceil(count ? count / (pagination?.pageSize || 20) : 0);
+    const calculatedPageCount = Math.ceil(count ? count / (pagination?.pageSize || 10) : 0);
 
     const table = useReactTable({
         data,
@@ -116,7 +116,7 @@ export function BaseTable<TData, TValue>({
     );
 
     const TableSkeleton = () => {
-        const rows = data.length > 0 ? data.length : pagination?.pageSize || pageSize || 20;
+        const rows = data.length > 0 ? data.length : pagination?.pageSize || pageSize || 10;
         return (
             <>
                 <SessionHistorySkeleton rows={rows} columns={columns} />

--- a/src/components/tables/base-table/index.tsx
+++ b/src/components/tables/base-table/index.tsx
@@ -52,7 +52,7 @@ export function BaseTable<TData, TValue>({
     data,
     count,
     pagination,
-    // setPagination,
+    setPagination,
     showToolBar,
     tableHeaderClassName,
     tableHeaderItemClassName,
@@ -63,7 +63,7 @@ export function BaseTable<TData, TValue>({
     emptyState,
     pageSize,
     session = true,
-    onRowSelectionChange
+    onRowSelectionChange,
 }: BaseTableProps<TData, TValue>) {
     const [sorting, setSorting] = useState<SortingState>([]);
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -73,13 +73,7 @@ export function BaseTable<TData, TValue>({
     const navigate = useNavigate();
     const user = JSON.parse(localStorage.getItem("user") || "{}");
 
-    const [paginationState, setPaginationState] = useState<PaginationState>(
-        pagination ?? { pageIndex: 0, pageSize: pageSize || 20 },
-    );
-
-    const currentPageSize = paginationState.pageSize;
-    const totalItems = count ?? data.length;
-    const calculatedPageCount = Math.max(1, Math.ceil(totalItems / currentPageSize));
+    const calculatedPageCount = Math.ceil(count ? count / (pagination?.pageSize || 20) : 0);
 
     const table = useReactTable({
         data,
@@ -87,7 +81,7 @@ export function BaseTable<TData, TValue>({
         state: {
             columnFilters,
             columnVisibility,
-            pagination: paginationState,
+            pagination,
             rowSelection,
             sorting,
         },
@@ -97,16 +91,16 @@ export function BaseTable<TData, TValue>({
         getSortedRowModel: getSortedRowModel(),
         onColumnFiltersChange: setColumnFilters,
         onColumnVisibilityChange: setColumnVisibility,
-        onPaginationChange: setPaginationState,
+        onPaginationChange: setPagination,
         onRowSelectionChange: setRowSelection,
         onSortingChange: setSorting,
         manualPagination: true,
     });
 
     useEffect(() => {
-        const selected = table.getSelectedRowModel().rows.map(r => r.original as TData);
+        const selected = table.getSelectedRowModel().rows.map((r) => r.original as TData);
         onRowSelectionChange?.(selected);
-    }, [rowSelection, table]);
+    }, [onRowSelectionChange, rowSelection, table]);
 
     const defaultEmptyState = (
         <TableRow>
@@ -186,10 +180,16 @@ export function BaseTable<TData, TValue>({
                                         }
                                     }}
                                     data-state={row.getIsSelected() && "selected"}
-                                    className={cn("hover:bg-bright-gray/50 data-[state=selected]:bg-bright-gray", tableRowClassName)}
+                                    className={cn(
+                                        "hover:bg-bright-gray/50 data-[state=selected]:bg-bright-gray",
+                                        tableRowClassName,
+                                    )}
                                 >
                                     {row.getVisibleCells().map((cell) => (
-                                        <TableCell key={cell.id} className={cn("text-dark-charcoal p-4 align-baseline", tableCellClassName)}>
+                                        <TableCell
+                                            key={cell.id}
+                                            className={cn("text-dark-charcoal p-4 align-baseline", tableCellClassName)}
+                                        >
                                             {flexRender(cell.column.columnDef.cell, cell.getContext())}
                                         </TableCell>
                                     ))}

--- a/src/components/tables/session-history-table/admin/index.tsx
+++ b/src/components/tables/session-history-table/admin/index.tsx
@@ -61,7 +61,7 @@ export function formatTime(time?: string): string {
 const SessionHistoryTable = () => {
     const [pagination, setPagination] = useState<PaginationState>({
         pageIndex: 0,
-        pageSize: 20,
+        pageSize: 10,
     });
     const { data, error, isLoading } = useSessionHistory(pagination.pageIndex + 1);
     const token = tokenManager.getToken();

--- a/src/components/tables/session-history-table/user/index.tsx
+++ b/src/components/tables/session-history-table/user/index.tsx
@@ -60,7 +60,7 @@ export function formatTime(time?: string): string {
 const SessionHistoryTable = () => {
     const [pagination, setPagination] = useState<PaginationState>({
         pageIndex: 0,
-        pageSize: 20,
+        pageSize: 10,
     });
     const { data, error, isLoading } = useSessionHistory(pagination.pageIndex + 1);
 


### PR DESCRIPTION
Adjust pagination settings to use a page size of 10 instead of 20 in both the base table and session history components. This change improves the user experience by displaying fewer items per page, making navigation easier. Additionally, ensure that pagination state is correctly managed and passed through the components.