### PR TITLE
fix: pagination in members table

### DIFF
--- a/src/hooks/organization/useFetchEnterpriseUsers.ts
+++ b/src/hooks/organization/useFetchEnterpriseUsers.ts
@@ -1,5 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
 import { apiGet } from "@/lib/api";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
 export interface User {
     id: number;
@@ -58,5 +58,6 @@ export function useFetchEnterpriseUsers(page?: number, id?: number) {
         enabled: true, // always enabled
         staleTime: 1000 * 60 * 5,
         retry: 1,
+        placeholderData: keepPreviousData,
     });
 }

--- a/src/hooks/use-data-table.ts
+++ b/src/hooks/use-data-table.ts
@@ -19,11 +19,12 @@ interface UseDataTableProps<TData>
             TableOptions<TData>,
             "state" | "pageCount" | "getCoreRowModel" | "manualFiltering" | "manualPagination" | "manualSorting"
         >,
-        Partial<Pick<TableOptions<TData>, "pageCount">> {
-    //! Change pageCount back to REQUIRED
+        Required<Pick<TableOptions<TData>, "pageCount">> {
     initialState?: Omit<Partial<TableState>, "sorting"> & {
         sorting?: ExtendedColumnSort<TData>[];
     };
+    pagination?: PaginationState;
+    setPagination?: React.Dispatch<React.SetStateAction<PaginationState>>;
     history?: "push" | "replace";
     debounceMs?: number;
     throttleMs?: number;
@@ -35,16 +36,12 @@ interface UseDataTableProps<TData>
 }
 
 export function useDataTable<TData>(props: UseDataTableProps<TData>) {
-    const [pagination, setPagination] = useState<PaginationState>({
-        pageIndex: 0,
-        pageSize: 15,
-    });
     const [sorting, setSorting] = useState<SortingState>([]);
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
     const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
     const [rowSelection, setRowSelection] = useState({});
 
-    const { columns, ...tableProps } = props;
+    const { columns, pagination, setPagination, ...tableProps } = props;
 
     const table = useReactTable({
         ...tableProps,
@@ -65,6 +62,7 @@ export function useDataTable<TData>(props: UseDataTableProps<TData>) {
         onPaginationChange: setPagination,
         onRowSelectionChange: setRowSelection,
         onSortingChange: setSorting,
+        manualPagination: true,
     });
 
     return { table };


### PR DESCRIPTION
Enhance the members table by implementing pagination, allowing users to navigate through entries more efficiently. Adjustments to data fetching and state management support this new functionality.